### PR TITLE
Uses ensure so that it unlocks even after an exception

### DIFF
--- a/lib/redis-lock.rb
+++ b/lib/redis-lock.rb
@@ -3,3 +3,5 @@ require File.dirname(__FILE__) + '/../lib/redis/lock'
 class Redis
   include Redis::Lock
 end
+
+class RedisLockException < Exception; end

--- a/lib/redis/lock.rb
+++ b/lib/redis/lock.rb
@@ -45,7 +45,7 @@ class Redis
           end
         end
       
-        raise "Unable to acquire lock for #{key}."
+        raise RedisLockException.new("Unable to acquire lock for #{key}.")
       rescue => e
         if e.message == "Unable to acquire lock for #{key}."
           if attempt_counter == max_attempts

--- a/lib/redis/lock.rb
+++ b/lib/redis/lock.rb
@@ -14,8 +14,12 @@ class Redis
     
     def lock_for_update(key, timeout = 60, max_attempts = 100)
       if self.lock(key, timeout, max_attempts)
-        response = yield if block_given?
-        self.unlock(key)
+        response = nil
+        begin
+          response = yield if block_given?
+        ensure
+          self.unlock(key)
+        end
         return response
       end
     end


### PR DESCRIPTION
What do you think?  Based on @mellop 's issue https://github.com/PatrickTulskie/redis-lock/issues/2
